### PR TITLE
Fix typos in documentation

### DIFF
--- a/Code/README.md
+++ b/Code/README.md
@@ -10,9 +10,9 @@ The Code folder contains:
 - Graph Theory Folder: Collection of scripts for Graph Theory
 - Hypercube Folder: JavaScript visualization of the hypercube (Tesseract)
 - Numerical Analysis Folder: Implementation of various numerical analysis methods
-- Partial Differential Equatons Fodler: Collection of PDEs scripts
+- Partial Differential Equations Folder: Collection of PDEs scripts
 - PiEstimate Folder: MATLAB estimation of Pi using Monte Carlo trials
-- Planetery Orbits Folder: Python scripts for cicular and elliptical orbits
+- Planetary Orbits Folder: Python scripts for circular and elliptical orbits
 - Quaternions Folder: 3D rotations using quaternions 
 
 <br/><br/>

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ ODEs, PDEs, Fluid Mechanics, Combinatorics and Dynamical Systems:
 - Hypercube Folder: JavaScript visualization of the hypercube (Tesseract)
 - Number Theory Folder: Collection of Number Theory scripts
 - Numerical Analysis Folder: Implementation of various numerical analysis methods
-- Partial Differential Equatons Fodler: Collection of PDEs scripts
+- Partial Differential Equations Folder: Collection of PDEs scripts
 - PiEstimate Folder: MATLAB estimation of Pi using Monte Carlo trials
-- Planetery Orbits Folder: Python scripts for cicular and elliptical orbits
+- Planetary Orbits Folder: Python scripts for circular and elliptical orbits
 - Quaternions Folder: 3D rotations using quaternions 
 
 <br/><br/>


### PR DESCRIPTION
## Summary
- fix spelling of Partial Differential Equations Folder
- fix spelling for Planetary Orbits Folder entry

## Testing
- `go test` *(fails: cannot find main module)*

------
https://chatgpt.com/codex/tasks/task_e_68492bb3d8a88326a592c60d6c619aeb