### PR TITLE
Fix Fortuna nanosecond seeding and build

### DIFF
--- a/Code/Cryptography/Fortuna/GoLang/common.go
+++ b/Code/Cryptography/Fortuna/GoLang/common.go
@@ -56,12 +56,12 @@ type SeedingError struct {
 	Msg string
 }
 
-func (e SeedingError) String() string { return "crypto/fortuna: " + e.Msg }
+func (e SeedingError) Error() string { return "crypto/fortuna: " + e.Msg }
 
 // currentTimeMillis returns the current time in milliseconds since the Unix
 // epoch.
 func currentTimeMillis() int64 {
-	result := time.Nanoseconds()
+	result := time.Now().UnixNano()
 	return result / 1e6
 }
 

--- a/Code/Cryptography/Fortuna/GoLang/fortuna_test.go
+++ b/Code/Cryptography/Fortuna/GoLang/fortuna_test.go
@@ -46,7 +46,7 @@ func TestFortuna_N(t *testing.T) {
 
 func seed(prng *SynchronizedPRNG) {
 	for i := 0; i < 8*32; i++ {
-		prng.Seed(time.Nanoseconds())
+		prng.Seed(time.Now().UnixNano())
 		time.Sleep(1e6) // 1 ms
 	}
 }

--- a/Code/Cryptography/Fortuna/GoLang/generator_test.go
+++ b/Code/Cryptography/Fortuna/GoLang/generator_test.go
@@ -1,4 +1,3 @@
-
 package fortuna
 
 import (
@@ -48,7 +47,7 @@ func TestGenerator_N(t *testing.T) {
 func TestSeed(t *testing.T) {
 	prng1 := NewUnseededGenerator()
 	prng2 := NewUnseededGenerator()
-	seed := time.Nanoseconds()
+	seed := time.Now().UnixNano()
 	prng1.Seed(seed)
 	prng2.Seed(seed)
 	for i := 0; i < 1000; i++ {

--- a/Code/Cryptography/Fortuna/GoLang/rand.go
+++ b/Code/Cryptography/Fortuna/GoLang/rand.go
@@ -1,8 +1,7 @@
-
 package fortuna
 
 import (
-	"rand"
+	"math/rand"
 )
 
 var globalRand = rand.New(globalSyncronizedFortuna)
@@ -46,8 +45,7 @@ func Perm(n int) []int { return globalRand.Perm(n) }
 // To produce a different normal distribution, callers can
 // adjust the output using:
 //
-//  sample = NormFloat64() * desiredStdDev + desiredMean
-//
+//	sample = NormFloat64() * desiredStdDev + desiredMean
 func NormFloat64() float64 { return globalRand.NormFloat64() }
 
 // ExpFloat64 returns an exponentially distributed float64 in the range
@@ -56,6 +54,5 @@ func NormFloat64() float64 { return globalRand.NormFloat64() }
 // To produce a distribution with a different rate parameter,
 // callers can adjust the output using:
 //
-//  sample = ExpFloat64() / desiredRateParameter
-//
+//	sample = ExpFloat64() / desiredRateParameter
 func ExpFloat64() float64 { return globalRand.ExpFloat64() }

--- a/Code/Cryptography/Fortuna/GoLang/seed.go
+++ b/Code/Cryptography/Fortuna/GoLang/seed.go
@@ -15,7 +15,7 @@ func writeSeedFile(prng *Fortuna) bool {
 	logTrace("--> writeSeedFile()")
 	f, e1 := openSeedFile(os.O_WRONLY)
 	if e1 != nil {
-		logError("writeSeedFile(): Failed opening random seed file: " + e1.String())
+		logError("writeSeedFile(): Failed opening random seed file: " + e1.Error())
 		return false
 	}
 
@@ -24,13 +24,13 @@ func writeSeedFile(prng *Fortuna) bool {
 	buffer := make([]byte, 64)
 	_, e2 := prng.Read(buffer)
 	if e2 != nil {
-		logError("writeSeedFile(): Failed obtaining random seed data: " + e2.String())
+		logError("writeSeedFile(): Failed obtaining random seed data: " + e2.Error())
 		return false
 	}
 
 	_, e3 := f.Write(buffer)
 	if e3 != nil {
-		logError("writeSeedFile(): Failed writing to random seed file: " + e3.String())
+		logError("writeSeedFile(): Failed writing to random seed file: " + e3.Error())
 		return false
 	}
 
@@ -56,18 +56,18 @@ func updateSeedFile(prng *Fortuna) bool {
 			logInfo("updateSeedFile(): About to create random seed file")
 			e11 := createSeedFile()
 			if e11 != nil {
-				logError("updateSeedFile(): Failed creating random seed file: " + e11.String())
+				logError("updateSeedFile(): Failed creating random seed file: " + e11.Error())
 			} else {
 				result = writeSeedFile(prng)
 			}
 		} else {
-			logError("updateSeedFile(): Failed opening random seed file: " + e1.String())
+			logError("updateSeedFile(): Failed opening random seed file: " + e1.Error())
 		}
 	} else {
 		s := make([]byte, 128)
 		n, e2 := f.Read(s)
 		if e2 != nil {
-			logError("updateSeedFile(): Failed reading random seed file: " + e2.String())
+			logError("updateSeedFile(): Failed reading random seed file: " + e2.Error())
 			f.Close()
 		} else {
 			if n != 64 {
@@ -105,12 +105,12 @@ func updateSeedPeriodically(f *Fortuna) {
 }
 
 // openSeedFile opens the Fortuna user's random seed file.
-func openSeedFile(flag int) (*os.File, os.Error) {
+func openSeedFile(flag int) (*os.File, error) {
 	return os.OpenFile(getSeedFilePath(), flag, 0600) // only u can r+w
 }
 
 // createSeedFile creates the file name and all parent sub-directories.
-func createSeedFile() os.Error {
+func createSeedFile() error {
 	// NOTE (rsn) - the next commented out statements were for trying to use
 	// $HOME/.go as the location for the random seed file.  we now use $GOROOT
 	// which MUST be always there

--- a/Code/Cryptography/Fortuna/GoLang/sync.go
+++ b/Code/Cryptography/Fortuna/GoLang/sync.go
@@ -1,7 +1,6 @@
 package fortuna
 
 import (
-	"os"
 	"sync"
 )
 
@@ -35,7 +34,7 @@ func (sg *SynchronizedPRNG) Seed(seed int64) {
 
 func (sg *SynchronizedPRNG) Int63() int64 { return int63(sg) }
 
-func (sg *SynchronizedPRNG) Read(buffer []byte) (n int, err os.Error) {
+func (sg *SynchronizedPRNG) Read(buffer []byte) (n int, err error) {
 	sg.lock.Lock()
 	defer sg.lock.Unlock()
 	return sg.prng.Read(buffer)


### PR DESCRIPTION
## Summary
- replace deprecated `time.Nanoseconds()` with `time.Now().UnixNano()`
- adjust seed comments accordingly
- modernize Fortuna PRNG implementation to compile on recent Go

## Testing
- `GO111MODULE=off go test ./Code/Cryptography/Fortuna/GoLang -c`

------
https://chatgpt.com/codex/tasks/task_e_68492bd0b9bc8326abaeef5552cc47bc